### PR TITLE
Refactor GrabberService during Workshop

### DIFF
--- a/config/disallowlist.php
+++ b/config/disallowlist.php
@@ -1,0 +1,69 @@
+<?php
+
+$imageBlackListWaspo = [
+    'logo-neu.jpg',
+    'youtube.png',
+    'instagram.png',
+    'facebook.png',
+];
+
+$imageBlackListSpandau = [
+    'logo-spandau',
+    '80x80',
+    'plugins',
+];
+
+$imageBlackListTotalWaterpolo = [
+    'facebook.com',
+    'w3.org',
+    'water-polo-community.png',
+    'Screen-Shot',
+    'Award-Badge',
+];
+
+$imageBlackListWasserballecke = [
+    'wasserballecke_',
+    'banner',
+    'gravatar',
+    '.gif',
+    'image3',
+    'ios_splasscreen',
+    'appack',
+    'googleplay',
+    'data:image',
+    'IMG_2165-1200x480.jpg', // Sharks logo
+];
+
+$imageBlackListSsvEsslingen = [
+    'logo.png',
+];
+
+$imageBlackListDeutscheWasserballLiga = [
+    'sportmuck',
+    'logo',
+];
+
+$imageBlackListProRecco = [
+    'lutto.jpg',
+    'WA0005',
+    'contattaci.jpg',
+    'INTELS.png',
+    'turbo.png',
+    'tossini.png',
+    'video_prorecco.jpg',
+];
+
+$imageBlackListDanceHr = [
+    'grb-udruga-opt.png',
+];
+
+return array_merge(
+    $imageBlackListWaspo,
+    $imageBlackListSpandau,
+    $imageBlackListTotalWaterpolo,
+    $imageBlackListWasserballecke,
+    $imageBlackListSsvEsslingen,
+    $imageBlackListDeutscheWasserballLiga,
+    $imageBlackListProRecco,
+    $imageBlackListDanceHr
+);

--- a/config/packages/waterpolo.yaml
+++ b/config/packages/waterpolo.yaml
@@ -1,0 +1,46 @@
+parameters:
+  remove-links-selector:
+    - '.section-related-ul'
+  waterpolo:
+    1:
+      domain: "www.deutsche-wasserball-liga.de"
+      page-type: "website"
+      image: 'img'
+      title: 'h1'
+      more-link: '.btn-more'
+    2:
+      domain: 'ssv-esslingen.de'
+      page-type: 'wordpress'
+      tags:
+        - 'category'
+      remove-links-selector:
+        - '.page-img'
+    3:
+      domain: 'h2o-polo.de'
+      page-type: 'wordpress'
+    4:
+      domain: 'homepage.svl08.com'
+      page-type: 'website'
+      image: '#newscontainer > div > p:nth-child(3) > img'
+      title: '.news_title'
+      more-link: '#newscontainer > div > p:nth-child(3) > a'
+    5:
+      domain: 'spandau04.de'
+      page-type: 'wordpress'
+      tags:
+        - 'category'
+    6:
+      domain: 'wasserballecke.de'
+      page-type: 'wordpress'
+    7:
+      domain: 'total-waterpolo.com'
+      page-type: 'wordpress'
+
+      remove-links-selector:
+        - '.hustle-ui'
+    8:
+      domain: 'waspo98.de'
+      page-type: 'wordpress'
+    9:
+      domain: 'www.dance.hr'
+      page-type: 'wordpress'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -42,3 +42,8 @@ services:
         class: \Google_Service_YouTube
         arguments:
             - '@Google_Client'
+
+    App\Service\GrabberService:
+        arguments:
+            $sourceDomains: '%waterpolo%'
+            $removeSelectors: '%remove-links-selector%'

--- a/tests/unit/Service/GrabberServiceTest.php
+++ b/tests/unit/Service/GrabberServiceTest.php
@@ -11,18 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class GrabberServiceTest extends TestCase
 {
-    public function testGetItemsReduceSourceDomainsOnDebugFirstDomain()
-    {
-        $wordpressGrabber = $this->createMock(WordpressGrabber::class);
-        $websiteGrabber = $this->createMock(WebsiteGrabber::class);
-        $imageHandler = $this->createMock(ImageHandler::class);
-
-        $grabberService = new GrabberService($wordpressGrabber, $websiteGrabber, $imageHandler);
-        $sourceDomains = $grabberService->getItems('firstDomain')['sourceDomains'];
-
-        $this->assertCount(1, $sourceDomains);
-    }
-
     public function testGetNewsByFirstDomainWhenPageTypeIsWebsite()
     {
         $wordpressGrabber = $this->createMock(WordpressGrabber::class);
@@ -36,8 +24,17 @@ class GrabberServiceTest extends TestCase
         };
         $imageHandler = $this->createMock(ImageHandler::class);
 
-        $grabberService = new GrabberService($wordpressGrabber, $websiteGrabber, $imageHandler);
-        $items = $grabberService->getItems('firstDomain');
+        $sourceDomains = [
+            [
+                'domain' => "www.deutsche-wasserball-liga.de",
+                'page-type' => "website",
+                'image' => 'img',
+                'title' => 'h1',
+                'more-link' => '.btn-more',
+            ]
+        ];
+        $grabberService = new GrabberService($wordpressGrabber, $websiteGrabber, $imageHandler, $sourceDomains);
+        $items = $grabberService->getItems();
 
         self::assertCount(1, $items['news']);
         self::assertSame('test', $items['news'][0]);


### PR DESCRIPTION
We moved the configurations into own files, one plain PHP-FIle that is
then included via `include` and one into a parameters-file for Symfony
and then we uses dependency injection to inject those config values into
the class which allows us to more easily test the class.

Additionally we removed some by now unused code as the affected path
could not be reached anymore.

And then we removed some code-duplication by adding some more config
values and running the deduplicated code against those config
informations. This removes hard-coded dependencies and also makes sure
that only code is executed that is relevant.

All in all we already reduced the file-size by 2/5 but I assume there is
more to come.